### PR TITLE
Make game mode hooks coroutines

### DIFF
--- a/GameModes/ArmsRaceHandler.cs
+++ b/GameModes/ArmsRaceHandler.cs
@@ -25,17 +25,17 @@
 
         public override void PlayerJoined(Player player)
         {
-            ((GM_ArmsRace)this.GameMode).PlayerJoined(player);
+            this.GameMode.PlayerJoined(player);
         }
 
         public override void PlayerDied(Player killedPlayer, int playersAlive)
         {
-            ((GM_ArmsRace) this.GameMode).PlayerDied(killedPlayer, playersAlive);
+            this.GameMode.PlayerDied(killedPlayer, playersAlive);
         }
 
         public override void StartGame()
         {
-            ((GM_ArmsRace) this.GameMode).StartGame();
+            this.GameMode.StartGame();
         }
 
         public override void ChangeSetting(string name, object value)
@@ -45,7 +45,7 @@
             if (name == "roundsToWinGame")
             {
                 int roundsToWinGame = (int) value;
-                ((GM_ArmsRace) this.GameMode).roundsToWinGame = roundsToWinGame;
+                this.GameMode.roundsToWinGame = roundsToWinGame;
                 UIHandler.instance.InvokeMethod("SetNumberOfRounds", roundsToWinGame);
             }
 

--- a/GameModes/ArmsRaceHandler.cs
+++ b/GameModes/ArmsRaceHandler.cs
@@ -25,17 +25,17 @@
 
         public override void PlayerJoined(Player player)
         {
-            this.GameMode.PlayerJoined(player);
+            ((GM_ArmsRace)this.GameMode).PlayerJoined(player);
         }
 
         public override void PlayerDied(Player killedPlayer, int playersAlive)
         {
-            this.GameMode.PlayerDied(killedPlayer, playersAlive);
+            ((GM_ArmsRace) this.GameMode).PlayerDied(killedPlayer, playersAlive);
         }
 
         public override void StartGame()
         {
-            this.GameMode.StartGame();
+            ((GM_ArmsRace) this.GameMode).StartGame();
         }
 
         public override void ChangeSetting(string name, object value)
@@ -45,7 +45,7 @@
             if (name == "roundsToWinGame")
             {
                 int roundsToWinGame = (int) value;
-                this.GameMode.roundsToWinGame = roundsToWinGame;
+                ((GM_ArmsRace) this.GameMode).roundsToWinGame = roundsToWinGame;
                 UIHandler.instance.InvokeMethod("SetNumberOfRounds", roundsToWinGame);
             }
 

--- a/GameModes/GameModeHandler.cs
+++ b/GameModes/GameModeHandler.cs
@@ -20,7 +20,7 @@ namespace UnboundLib.GameModes
         // Used to find the correct game mode from scene
         private readonly string gameModeId;
 
-        private Dictionary<string, Func<IGameModeHandler, IEnumerator>> hooks = new Dictionary<string, Func<IGameModeHandler, IEnumerator>>();
+        private Dictionary<string, List<Func<IGameModeHandler, IEnumerator>>> hooks = new Dictionary<string, List<Func<IGameModeHandler, IEnumerator>>>();
 
         protected GameModeHandler(string gameModeId)
         {
@@ -34,27 +34,30 @@ namespace UnboundLib.GameModes
 
             if (!this.hooks.ContainsKey(key))
             {
-                this.hooks.Add(key, action);
+                this.hooks.Add(key, new List<Func<IGameModeHandler, IEnumerator>> { action });
             }
             else
             {
-                this.hooks[key] += action;
+                this.hooks[key].Add(action);
             }
         }
 
         public void RemoveHook(string key, Func<IGameModeHandler, IEnumerator> action)
         {
-            this.hooks[key.ToLower()] -= action;
+            this.hooks[key.ToLower()].Remove(action);
         }
 
         public IEnumerator TriggerHook(string key)
         {
-            Func<IGameModeHandler, IEnumerator> hook;
-            this.hooks.TryGetValue(key.ToLower(), out hook);
+            List<Func<IGameModeHandler, IEnumerator>> hooks;
+            this.hooks.TryGetValue(key.ToLower(), out hooks);
 
-            if (hook != null)
+            if (hooks != null)
             {
-                yield return hook(this);
+                foreach (var h in hooks)
+                {
+                    if (h != null) yield return h(this);
+                }
             }
         }
 

--- a/GameModes/GameModeHandler.cs
+++ b/GameModes/GameModeHandler.cs
@@ -5,12 +5,20 @@ using UnityEngine;
 
 namespace UnboundLib.GameModes
 {
-    public abstract class GameModeHandler<T> : IGameModeHandler where T : MonoBehaviour
+    public abstract class GameModeHandler<T> : IGameModeHandler<T> where T : MonoBehaviour
     {
-        public MonoBehaviour GameMode {
+        public T GameMode {
             get
             {
                 return GameModeManager.GetGameMode<T>(this.gameModeId);
+            }
+        }
+
+        MonoBehaviour IGameModeHandler.GameMode
+        {
+            get
+            {
+                return this.GameMode;
             }
         }
 

--- a/GameModes/GameModeHandler.cs
+++ b/GameModes/GameModeHandler.cs
@@ -37,6 +37,11 @@ namespace UnboundLib.GameModes
 
         public void AddHook(string key, Func<IGameModeHandler, IEnumerator> action)
         {
+            if (action == null)
+            {
+                return;
+            }
+
             // Case-insensitive keys for QoL
             key = key.ToLower();
 
@@ -62,9 +67,9 @@ namespace UnboundLib.GameModes
 
             if (hooks != null)
             {
-                foreach (var h in hooks)
+                foreach (var hook in hooks)
                 {
-                    if (h != null) yield return h(this);
+                    yield return hook(this);
                 }
             }
         }

--- a/GameModes/GameModeManager.cs
+++ b/GameModes/GameModeManager.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
@@ -7,7 +8,6 @@ using ExitGames.Client.Photon;
 
 namespace UnboundLib.GameModes
 {
-
     public static class GameModeManager
     {
         private static Dictionary<string, IGameModeHandler> handlers = new Dictionary<string, IGameModeHandler>();
@@ -74,12 +74,12 @@ namespace UnboundLib.GameModes
             };
         }
 
-        public static void TriggerHook(string hook)
+        public static IEnumerator TriggerHook(string hook)
         {
-            GameModeManager.CurrentHandler?.TriggerHook(hook);
+            yield return GameModeManager.CurrentHandler?.TriggerHook(hook);
         }
 
-        public static void AddHook(string key, Action<IGameModeHandler> action)
+        public static void AddHook(string key, Func<IGameModeHandler, IEnumerator> action)
         {
             key = key.ToLower();
             foreach (var handler in GameModeManager.handlers.Values)
@@ -88,7 +88,7 @@ namespace UnboundLib.GameModes
             }
         }
 
-        public static void RemoveHook(string key, Action<IGameModeHandler> action)
+        public static void RemoveHook(string key, Func<IGameModeHandler, IEnumerator> action)
         {
             key = key.ToLower();
             foreach (var handler in GameModeManager.handlers.Values)

--- a/GameModes/IGameModeHandler.cs
+++ b/GameModes/IGameModeHandler.cs
@@ -48,4 +48,9 @@ namespace UnboundLib.GameModes
         /// </summary>
         void StartGame();
     }
+
+    public interface IGameModeHandler<T> : IGameModeHandler where T : MonoBehaviour
+    {
+        new T GameMode { get; }
+    }
 }

--- a/GameModes/IGameModeHandler.cs
+++ b/GameModes/IGameModeHandler.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections;
+using UnityEngine;
 
 namespace UnboundLib.GameModes
 {
@@ -13,15 +15,17 @@ namespace UnboundLib.GameModes
     /// </summary>
     public interface IGameModeHandler
     {
+        MonoBehaviour GameMode { get; }
+
         GameSettings Settings { get; }
 
         string Name { get; }
 
-        void RemoveHook(string key, Action<IGameModeHandler> action);
+        void RemoveHook(string key, Func<IGameModeHandler, IEnumerator> action);
 
-        void AddHook(string key, Action<IGameModeHandler> action);
+        void AddHook(string key, Func<IGameModeHandler, IEnumerator> action);
 
-        void TriggerHook(string key);
+        IEnumerator TriggerHook(string key);
 
         void SetSettings(GameSettings settings);
 

--- a/Patches/GM_ArmsRace.cs
+++ b/Patches/GM_ArmsRace.cs
@@ -49,7 +49,7 @@ namespace UnboundLib.Patches
         }
     }
 
-    [HarmonyPatch(typeof(GM_ArmsRace), "PlayerJoined")]
+    [HarmonyPatch(typeof(GM_ArmsRace), "Start")]
     public class GM_ArmsRace_Patch_Start
     {
 
@@ -289,7 +289,7 @@ namespace UnboundLib.Patches
     }
 
     [HarmonyPatch(typeof(GM_ArmsRace), "GameOverTransition")]
-    class GM_ArmsRace_Patch_GameOver
+    class GM_ArmsRace_Patch_GameOverTransition
     {
         static IEnumerator Postfix(IEnumerator e)
         {

--- a/Patches/Player.cs
+++ b/Patches/Player.cs
@@ -1,4 +1,5 @@
 ﻿using HarmonyLib;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using UnboundLib.GameModes;
@@ -41,14 +42,17 @@ namespace UnboundLib.Patches
         {
             if (__instance.data.view.IsMine)
             {
-                GameModeManager.AddHook(GameModeHooks.HookGameStart, (gm) =>
-                {
-                    if (gm.Name != "Sandbox")
-                    {
-                        __instance.GetFaceOffline();
-                    }
-                });
+                GameModeManager.AddHook(GameModeHooks.HookGameStart, gm => OnGameStart(gm, __instance));
             }
+        }
+
+        static IEnumerator OnGameStart(IGameModeHandler gm, Player player)
+        {
+            if (gm.Name != "Sandbox")
+            {
+                player.GetFaceOffline();
+            }
+            yield break;
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@ Example usage:
 	
 	private const string MessageEvent = "YourMod_MessageEvent";
 
-	NetworkingManager.RegisterEvent(MessageEvent, (data) => {
-	  ModLoader.BuildInfoPopup("Test Event Message: " + (string)data[0]);    // should print "Test Event Message: Hello World!"
+	NetworkingManager.RegisterEvent(MessageEvent, (data) =>
+	{
+		ModLoader.BuildInfoPopup("Test Event Message: " + (string)data[0]);    // should print "Test Event Message: Hello World!"
 	});
 
 	// send event to other clients only
@@ -25,7 +26,7 @@ Create a class for your card, extend the **CustomCard** class, implement its met
 
   	void Start()
   	{
-	  CustomCard.BuildCard<TestCard>();
+		CustomCard.BuildCard<TestCard>();
   	}
 
 # GameMode Framework
@@ -39,26 +40,41 @@ The framework offers a flexible hook system. With hooks, mods can trigger action
 anything about the specific game mode or its implementation.
 
 ### Triggering hooks
-Game modes can trigger hooks whenever they wish:
+Game modes can trigger async hooks whenever they wish:
 
 ```csharp
-private void RoundStart() {
-  // Hook keys are case-insensitive
-  GameModeManager.TriggerHook("RoundStart");
+private IEnumerator RoundStart()
+{
+	// Hook keys are case-insensitive
+	yield return GameModeManager.TriggerHook("RoundStart");
 
-  // A healthy set of predefined keys is provided to make hooking on to them easier.
-  // Predefined keys should be used in favour of custom ones when possible.
-  GameModeManager.TriggerHook(GameModeHooks.HookRoundStart);
+	// A healthy set of predefined keys is provided to make hooking on to them easier.
+	// Predefined keys should be used in favour of custom ones when possible.
+	yield return GameModeManager.TriggerHook(GameModeHooks.HookRoundStart);
 }
 ```
 
 ### Registering hooks
-and mods can register hook listeners wherever they wish:
+Mods can register hook listeners wherever they wish:
 
 ```csharp
-private void Init() {
-  // Hooks are called with the game mode that triggered the hook, which is always the currently active game mode
-  GameModeManager.AddHook(GameModeHooks.HookRoundStart, (gm) => UnityEngine.Debug.Log(gm.Name));
+private void Init()
+{
+	// Hooks are called with the game mode that triggered the hook, which is always the currently active game mode
+	GameModeManager.AddHook(GameModeHooks.HookRoundStart, this.OnRoundStart);
+}
+
+private IEnumerator OnRoundStart(IGameModeHandler gm)
+{
+	// Triggers are IEnumerators so they support yields
+	yield return new WaitForSeconds(2f);
+
+	UnityEngine.Debug.Log(gm.Name);
+
+	/* Since triggers are IEnumerators, they must be executed within a coroutine. This means triggers are guaranteed to
+	 * be able to disrupt the execution of the current game mode.
+	 */
+	gm.GameMode.StopAllCoroutines();
 }
 ```
 
@@ -71,8 +87,10 @@ but they place a lot of responsibility onto game modes to provide sufficient set
 ### Using settings in a game mode
 
 ```csharp
-private void CheckPoints() {
-	if (p1Points >= (int)GameModeManager.CurrentHandler.Settings["pointsToWinRound"]) {
+private void CheckPoints()
+{
+	if (p1Points >= (int)GameModeManager.CurrentHandler.Settings["pointsToWinRound"])
+	{
 		WinRound();
 	}
 }
@@ -81,11 +99,14 @@ private void CheckPoints() {
 ### Changing settings (in a mod)
 
 ```csharp
-private void Init() {
-	GameModeManager.AddHook(GameModeHooks.HookInitEnd, (gm) =>
-	{
-		gm.ChangeSetting("pointsToWinRound", 10);
-	});
+private void Init()
+{
+	GameModeManager.AddHook(GameModeHooks.HookInitEnd, this.OnInitEnd);
+}
+
+private IEnumerator OnInitEnd(GameModeHandler gm)
+{
+	gm.ChangeSetting("pointsToWinRound", 10);
 }
 ```
 

--- a/Unbound.cs
+++ b/Unbound.cs
@@ -13,7 +13,7 @@ using UnityEngine.UI;
 
 namespace UnboundLib
 {
-    [BepInPlugin(ModId, ModName, "1.1.2")]
+    [BepInPlugin(ModId, ModName, "2.0.0")]
     [BepInProcess("Rounds.exe")]
     public class Unbound : BaseUnityPlugin
     {
@@ -100,6 +100,18 @@ namespace UnboundLib
                 if (text != null) Destroy(text.gameObject);
 
                 orig(self);
+            };
+
+            IEnumerator ArmsRaceStartCoroutine(On.GM_ArmsRace.orig_Start orig, GM_ArmsRace self)
+            {
+                yield return GameModeManager.TriggerHook(GameModeHooks.HookInitStart);
+                orig(self);
+                yield return GameModeManager.TriggerHook(GameModeHooks.HookInitEnd);
+            }
+
+            On.GM_ArmsRace.Start += (orig, self) =>
+            {
+                self.StartCoroutine(ArmsRaceStartCoroutine(orig, self));
             };
         }
 

--- a/UnboundLib.csproj
+++ b/UnboundLib.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net461</TargetFramework>
+    <LangVersion>7.1</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The current hook system is useful if you want to just react to events happening in a game, but it does not allow you to really affect the gameplay directly. Async hooks change all of this, since it allows you to pause the game while you do meaningful work within hooks.

This breaks the current API, and so the version was bumped to 2.0.0. The readme contains usage examples.