### PR TITLE
Add reset and score tracking functionality to gm handlers

### DIFF
--- a/GameModes/ArmsRaceHandler.cs
+++ b/GameModes/ArmsRaceHandler.cs
@@ -12,19 +12,6 @@ namespace UnboundLib.GameModes
 
         public override GameSettings Settings { get; protected set; }
 
-        public override ReadOnlyDictionary<int, TeamScore> TeamScore {
-            get
-            {
-                var dict = new Dictionary<int, TeamScore>()
-                {
-                    { 0, new TeamScore(GM_ArmsRace.instance.p1Points, GM_ArmsRace.instance.p1Rounds) },
-                    { 1, new TeamScore(GM_ArmsRace.instance.p2Points, GM_ArmsRace.instance.p2Rounds) }
-                };
-
-                return new ReadOnlyDictionary<int, TeamScore>(dict);
-            }
-        }
-
         public ArmsRaceHandler() : base("Arms race")
         {
             this.Settings = new GameSettings()

--- a/GameModes/ArmsRaceHandler.cs
+++ b/GameModes/ArmsRaceHandler.cs
@@ -1,6 +1,9 @@
-﻿namespace UnboundLib.GameModes
+﻿using System.Collections.ObjectModel;
+using System.Collections.Generic;
+
+namespace UnboundLib.GameModes
 {
-    class ArmsRaceHandler : GameModeHandler<GM_ArmsRace>
+    public class ArmsRaceHandler : GameModeHandler<GM_ArmsRace>
     {
         public override string Name
         {
@@ -8,6 +11,19 @@
         }
 
         public override GameSettings Settings { get; protected set; }
+
+        public override ReadOnlyDictionary<int, TeamScore> TeamScore {
+            get
+            {
+                var dict = new Dictionary<int, TeamScore>()
+                {
+                    { 0, new TeamScore(GM_ArmsRace.instance.p1Points, GM_ArmsRace.instance.p1Rounds) },
+                    { 1, new TeamScore(GM_ArmsRace.instance.p2Points, GM_ArmsRace.instance.p2Rounds) }
+                };
+
+                return new ReadOnlyDictionary<int, TeamScore>(dict);
+            }
+        }
 
         public ArmsRaceHandler() : base("Arms race")
         {
@@ -33,9 +49,41 @@
             this.GameMode.PlayerDied(killedPlayer, playersAlive);
         }
 
+        public override TeamScore GetTeamScore(int teamID)
+        {
+            if (teamID != 0 && teamID != 1)
+            {
+                return new TeamScore(0, 0);
+            }
+
+            return teamID == 0
+                ? new TeamScore(GM_ArmsRace.instance.p1Points, GM_ArmsRace.instance.p1Rounds)
+                : new TeamScore(GM_ArmsRace.instance.p2Points, GM_ArmsRace.instance.p2Rounds);
+        }
+
+        public override void SetTeamScore(int teamID, TeamScore score)
+        {
+            if (teamID == 0)
+            {
+                this.GameMode.p1Points = score.points;
+                this.GameMode.p1Rounds = score.rounds;
+            }
+            if (teamID == 1)
+            {
+                this.GameMode.p2Points = score.points;
+                this.GameMode.p2Rounds = score.rounds;
+            }
+        }
+
         public override void StartGame()
         {
             this.GameMode.StartGame();
+        }
+
+        public override void ResetGame()
+        {
+            PlayerManager.instance.InvokeMethod("ResetCharacters");
+            GM_ArmsRace.instance.InvokeMethod("ResetMatch");
         }
 
         public override void ChangeSetting(string name, object value)

--- a/GameModes/GameModeHandler.cs
+++ b/GameModes/GameModeHandler.cs
@@ -1,10 +1,12 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using UnityEngine;
 
 namespace UnboundLib.GameModes
 {
+    /// <inheritdoc/>
     public abstract class GameModeHandler<T> : IGameModeHandler<T> where T : MonoBehaviour
     {
         public T GameMode {
@@ -24,6 +26,7 @@ namespace UnboundLib.GameModes
 
         public abstract GameSettings Settings { get; protected set; }
         public abstract string Name { get; }
+        public abstract ReadOnlyDictionary<int, TeamScore> TeamScore { get; }
 
         // Used to find the correct game mode from scene
         private readonly string gameModeId;
@@ -100,8 +103,14 @@ namespace UnboundLib.GameModes
 
         public abstract void PlayerDied(Player killedPlayer, int playersAlive);
 
+        public abstract TeamScore GetTeamScore(int teamID);
+
+        public abstract void SetTeamScore(int teamID, TeamScore score);
+
         public abstract void SetActive(bool active);
 
         public abstract void StartGame();
+
+        public abstract void ResetGame();
     }
 }

--- a/GameModes/GameModeHandler.cs
+++ b/GameModes/GameModeHandler.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using UnityEngine;
 
 namespace UnboundLib.GameModes
@@ -26,7 +25,6 @@ namespace UnboundLib.GameModes
 
         public abstract GameSettings Settings { get; protected set; }
         public abstract string Name { get; }
-        public abstract ReadOnlyDictionary<int, TeamScore> TeamScore { get; }
 
         // Used to find the correct game mode from scene
         private readonly string gameModeId;

--- a/GameModes/IGameModeHandler.cs
+++ b/GameModes/IGameModeHandler.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections;
-using System.Collections.ObjectModel;
 using UnityEngine;
 
 namespace UnboundLib.GameModes
@@ -19,8 +18,6 @@ namespace UnboundLib.GameModes
         MonoBehaviour GameMode { get; }
 
         GameSettings Settings { get; }
-
-        ReadOnlyDictionary<int, TeamScore> TeamScore { get; }
 
         string Name { get; }
 

--- a/GameModes/IGameModeHandler.cs
+++ b/GameModes/IGameModeHandler.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections;
+using System.Collections.ObjectModel;
 using UnityEngine;
 
 namespace UnboundLib.GameModes
@@ -19,6 +20,8 @@ namespace UnboundLib.GameModes
 
         GameSettings Settings { get; }
 
+        ReadOnlyDictionary<int, TeamScore> TeamScore { get; }
+
         string Name { get; }
 
         void RemoveHook(string key, Func<IGameModeHandler, IEnumerator> action);
@@ -36,6 +39,20 @@ namespace UnboundLib.GameModes
         void PlayerDied(Player killedPlayer, int playersAlive);
 
         /// <summary>
+        ///     Should return the current score of a team. This value should reflect the state of the actual game when applicable.
+        /// </summary>
+        /// <param name="teamID">The ID of the team whose score should be returned.</param>
+        /// <returns></returns>
+        TeamScore GetTeamScore(int teamID);
+
+        /// <summary>
+        ///     Sets the current score of a team. Changing the score should reflect in the actual game when applicable.
+        /// </summary>
+        /// <param name="teamID">ID of the team whose score should be changed.</param>
+        /// <param name="score">Score to set for the team.</param>
+        void SetTeamScore(int teamID, TeamScore score);
+
+        /// <summary>
         ///     When true, should tell the game mode to activate and run any initialization code it might have.
         ///     When false, should tell the game mode to deactivate and hide any possible visual elements it might've drawn.
         ///     Typical behaviour is to activate or disable the game mode's gameobject.
@@ -47,6 +64,11 @@ namespace UnboundLib.GameModes
         ///     Should tell the game mode to start the game.
         /// </summary>
         void StartGame();
+
+        /// <summary>
+        ///     Should tell the game mode to reset any state, such as player score and cards. The game should NOT restart.
+        /// </summary>
+        void ResetGame();
     }
 
     public interface IGameModeHandler<T> : IGameModeHandler where T : MonoBehaviour

--- a/GameModes/SandboxHandler.cs
+++ b/GameModes/SandboxHandler.cs
@@ -1,7 +1,4 @@
-﻿using System.Collections.ObjectModel;
-using System.Collections.Generic;
-
-namespace UnboundLib.GameModes
+﻿namespace UnboundLib.GameModes
 {
     public class SandboxHandler : GameModeHandler<GM_Test>
     {
@@ -11,21 +8,6 @@ namespace UnboundLib.GameModes
         }
 
         public override GameSettings Settings { get; protected set; }
-
-        public override ReadOnlyDictionary<int, TeamScore> TeamScore
-        {
-            get
-            {
-                var dict = new Dictionary<int, TeamScore>();
-
-                foreach (var player in PlayerManager.instance.players)
-                {
-                    dict.Add(player.teamID, new TeamScore(0, 0));
-                }
-
-                return new ReadOnlyDictionary<int, TeamScore>(dict);
-            }
-        }
 
         public SandboxHandler() : base("Test") {
             this.Settings = new GameSettings();

--- a/GameModes/SandboxHandler.cs
+++ b/GameModes/SandboxHandler.cs
@@ -1,6 +1,9 @@
-﻿namespace UnboundLib.GameModes
+﻿using System.Collections.ObjectModel;
+using System.Collections.Generic;
+
+namespace UnboundLib.GameModes
 {
-    class SandboxHandler : GameModeHandler<GM_Test>
+    public class SandboxHandler : GameModeHandler<GM_Test>
     {
         public override string Name
         {
@@ -8,6 +11,21 @@
         }
 
         public override GameSettings Settings { get; protected set; }
+
+        public override ReadOnlyDictionary<int, TeamScore> TeamScore
+        {
+            get
+            {
+                var dict = new Dictionary<int, TeamScore>();
+
+                foreach (var player in PlayerManager.instance.players)
+                {
+                    dict.Add(player.teamID, new TeamScore(0, 0));
+                }
+
+                return new ReadOnlyDictionary<int, TeamScore>(dict);
+            }
+        }
 
         public SandboxHandler() : base("Test") {
             this.Settings = new GameSettings();
@@ -23,6 +41,13 @@
             this.GameMode.InvokeMethod("PlayerDied", killedPlayer, playersAlive);
         }
 
+        public override TeamScore GetTeamScore(int teamID)
+        {
+            return new TeamScore(0, 0);
+        }
+
+        public override void SetTeamScore(int teamID, TeamScore score) { }
+
         public override void SetActive(bool active)
         {
             if (!active)
@@ -34,6 +59,11 @@
         public override void StartGame()
         {
             this.GameMode.gameObject.SetActive(true);
+        }
+
+        public override void ResetGame()
+        {
+            PlayerManager.instance.InvokeMethod("ResetCharacters");
         }
     }
 }

--- a/GameModes/TeamScore.cs
+++ b/GameModes/TeamScore.cs
@@ -1,0 +1,14 @@
+﻿namespace UnboundLib.GameModes
+{
+    public struct TeamScore
+    {
+        public readonly int points;
+        public readonly int rounds;
+
+        public TeamScore(int points, int rounds)
+        {
+            this.points = points;
+            this.rounds = rounds;
+        }
+    }
+}

--- a/Unbound.cs
+++ b/Unbound.cs
@@ -13,7 +13,7 @@ using UnityEngine.UI;
 
 namespace UnboundLib
 {
-    [BepInPlugin(ModId, ModName, "2.0.0")]
+    [BepInPlugin(ModId, ModName, "2.1.0")]
     [BepInProcess("Rounds.exe")]
     public class Unbound : BaseUnityPlugin
     {


### PR DESCRIPTION
- Add reset and score tracking functionality to GameModeHandlers. I believe point and round score is common enough functionality to be added to the GameModeHandler interface. Same goes for reset-but-don't-restart.
- Bump version to 2.1.0.

Some silly examples:
```csharp
public void Start() {
  GameModeManager.AddHook(GameModeHooks.HookRoundEnd, this.OnRoundEnd);
}

// Example 1
// After every round, give the team with least round wins an extra round win
private IEnumerator OnRoundEnd(IGameModeHandler gm)
{
  int worstTeam = PlayerManager.instance.players
    .OrderBy(p => gm.GetTeamScore(p.teamID).rounds)
    .First()
    .teamID;

  var score = gm.GetTeamScore(worstTeam);
  gm.SetTeamScore(worstTeam, new TeamScore(score.points, score.rounds + 1));
  yield break;
}

// Example 2
// Reset the game after every round for some boring infinite gameplay
private IEnumerator OnRoundEnd(IGameModeHandler gm)
{
  gm.ResetGame(); // Not a restart, just a score/card reset
  yield break;
}
```