### PR TITLE
Move hook logic from GameModeHandlers to GameModeManager

### DIFF
--- a/GameModes/GameModeHandler.cs
+++ b/GameModes/GameModeHandler.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
+﻿using UnityEngine;
 
 namespace UnboundLib.GameModes
 {
@@ -29,50 +26,9 @@ namespace UnboundLib.GameModes
         // Used to find the correct game mode from scene
         private readonly string gameModeId;
 
-        private Dictionary<string, List<Func<IGameModeHandler, IEnumerator>>> hooks = new Dictionary<string, List<Func<IGameModeHandler, IEnumerator>>>();
-
         protected GameModeHandler(string gameModeId)
         {
             this.gameModeId = gameModeId;
-        }
-
-        public void AddHook(string key, Func<IGameModeHandler, IEnumerator> action)
-        {
-            if (action == null)
-            {
-                return;
-            }
-
-            // Case-insensitive keys for QoL
-            key = key.ToLower();
-
-            if (!this.hooks.ContainsKey(key))
-            {
-                this.hooks.Add(key, new List<Func<IGameModeHandler, IEnumerator>> { action });
-            }
-            else
-            {
-                this.hooks[key].Add(action);
-            }
-        }
-
-        public void RemoveHook(string key, Func<IGameModeHandler, IEnumerator> action)
-        {
-            this.hooks[key.ToLower()].Remove(action);
-        }
-
-        public IEnumerator TriggerHook(string key)
-        {
-            List<Func<IGameModeHandler, IEnumerator>> hooks;
-            this.hooks.TryGetValue(key.ToLower(), out hooks);
-
-            if (hooks != null)
-            {
-                foreach (var hook in hooks)
-                {
-                    yield return hook(this);
-                }
-            }
         }
 
         public void SetSettings(GameSettings settings)

--- a/GameModes/IGameModeHandler.cs
+++ b/GameModes/IGameModeHandler.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections;
-using UnityEngine;
+﻿using UnityEngine;
 
 namespace UnboundLib.GameModes
 {
@@ -20,12 +18,6 @@ namespace UnboundLib.GameModes
         GameSettings Settings { get; }
 
         string Name { get; }
-
-        void RemoveHook(string key, Func<IGameModeHandler, IEnumerator> action);
-
-        void AddHook(string key, Func<IGameModeHandler, IEnumerator> action);
-
-        IEnumerator TriggerHook(string key);
 
         void SetSettings(GameSettings settings);
 

--- a/Unbound.cs
+++ b/Unbound.cs
@@ -14,7 +14,7 @@ using UnityEngine.UI;
 
 namespace UnboundLib
 {
-    [BepInPlugin(ModId, ModName, "2.1.1")]
+    [BepInPlugin(ModId, ModName, "2.1.2")]
     [BepInProcess("Rounds.exe")]
     public class Unbound : BaseUnityPlugin
     {


### PR DESCRIPTION
Currently `GameModeManager.AddHook` adds the hook to only the existing game mode handlers, which can cause a host of timing issues and confusion if mods try to mix and match their init code in Await and Start. Storing hooks statically in `GameModeManager` avoids these issues and makes the code simpler.