### PR TITLE
Add once hooks and fix online lobbies

### DIFF
--- a/UnboundLib/Patches/Player.cs
+++ b/UnboundLib/Patches/Player.cs
@@ -6,7 +6,6 @@ using UnboundLib.GameModes;
 
 namespace UnboundLib.Patches
 {
-
     [HarmonyPatch(typeof(Player), "Start")]
     class Player_Patch_Start
     {
@@ -37,12 +36,16 @@ namespace UnboundLib.Patches
                 }
             }
         }
+    }
 
+    [HarmonyPatch(typeof(Player), "Awake")]
+    class Player_Patch_Awake
+    {
         static void Postfix(Player __instance)
         {
             if (__instance.data.view.IsMine)
             {
-                GameModeManager.AddHook(GameModeHooks.HookGameStart, gm => OnGameStart(gm, __instance));
+                GameModeManager.AddOnceHook(GameModeHooks.HookGameStart, gm => OnGameStart(gm, __instance));
             }
         }
 


### PR DESCRIPTION
Adds once hooks. There are currently no good ways to remove hooks from within hooks. While this PR doesn't solve the problem entirely, it is somewhat mitigated by providing hooks that are automatically removed after they are triggered once.

Also fixes issue where private lobbies would break after second invite. Adding an OnGameStart hook in `Player::Start` happens too slow, and the hook ends up being triggered before it's added. Since the hook isn't removed, it is still triggered when the second game starts. However, it is triggered for a player that no longer exists, which results in a broken lobby.

The memory leak (hooks are added for new players but not removed when players leave) and the broken lobby are both fixed by adding a once-hook in `Player::Awake`.