### PR TITLE
Make CardToggleMenuHandler public instead of interal

### DIFF
--- a/UnboundLib/Utils/UI/CardMenuHandlers.cs
+++ b/UnboundLib/Utils/UI/CardMenuHandlers.cs
@@ -11,7 +11,7 @@ using UnityEngine.Events;
 
 namespace UnboundLib
 {
-    internal class CardToggleMenuHandler : MonoBehaviour
+    public class CardToggleMenuHandler : MonoBehaviour
     {
         private GameObject _togglePrefab;
         private GameObject TogglePrefab


### PR DESCRIPTION
This is literally just so that I (and I suppose others as well) can patch methods of this class more easily.