### PR TITLE
Allow registering maps by name directly

### DIFF
--- a/UnboundLib/Unbound.cs
+++ b/UnboundLib/Unbound.cs
@@ -416,15 +416,16 @@ namespace UnboundLib
 
         public static void RegisterMaps(AssetBundle assetBundle)
         {
-            // extract scene paths
-            foreach (var path in assetBundle.GetAllScenePaths())
-            {
-                activeLevels.Add(path);
-            }
+            Unbound.RegisterMaps(assetBundle.GetAllScenePaths());
+        }
 
-            // update map list
+        public static void RegisterMaps(IEnumerable<string> paths)
+        {
+            activeLevels.AddRange(paths);
+            activeLevels = activeLevels.Distinct().ToList();
             MapManager.instance.levels = activeLevels.ToArray();
         }
+
         // loads a map in via its name prefixed with a forward-slash
         internal static void SpawnMap(string message)
         {


### PR DESCRIPTION
Currently custom maps can only be registered from asset bundles. By allowing map registration by name/path directly, mods can handle map loading by scene name in a more flexible way. This is needed by the upcoming map editor where scenes with a specific extension in their name (`.map`) are loaded from disk on demand.