### PR TITLE
Add Block component to SetupCard

### DIFF
--- a/UnboundLib/Cards/CustomCard.cs
+++ b/UnboundLib/Cards/CustomCard.cs
@@ -44,7 +44,10 @@ namespace UnboundLib.Cards
         protected abstract CardInfo.Rarity GetRarity();
         protected abstract GameObject GetCardArt();
         protected abstract CardThemeColor.CardThemeColorType GetTheme();
-        public abstract void SetupCard(CardInfo cardInfo, Gun gun, ApplyCardStats cardStats, CharacterStatModifiers statModifiers);
+        public virtual void SetupCard(CardInfo cardInfo, Gun gun, ApplyCardStats cardStats, CharacterStatModifiers statModifiers)
+        {
+
+        }
         public virtual void SetupCard(CardInfo cardInfo, Gun gun, ApplyCardStats cardStats, CharacterStatModifiers statModifiers, Block block)
         {
             SetupCard(cardInfo, gun, cardStats, statModifiers);

--- a/UnboundLib/Cards/CustomCard.cs
+++ b/UnboundLib/Cards/CustomCard.cs
@@ -17,6 +17,7 @@ namespace UnboundLib.Cards
         public Gun gun;
         public ApplyCardStats cardStats;
         public CharacterStatModifiers statModifiers;
+        public Block block;
         private bool isPrefab = false;
 
         void Awake()
@@ -25,7 +26,8 @@ namespace UnboundLib.Cards
             gun = GetComponent<Gun>();
             cardStats = GetComponent<ApplyCardStats>();
             statModifiers = GetComponent<CharacterStatModifiers>();
-            SetupCard(cardInfo, gun, cardStats, statModifiers);
+            block = GetComponent<Block>();
+            SetupCard(cardInfo, gun, cardStats, statModifiers, block);
         }
 
         void Start()
@@ -43,6 +45,10 @@ namespace UnboundLib.Cards
         protected abstract GameObject GetCardArt();
         protected abstract CardThemeColor.CardThemeColorType GetTheme();
         public abstract void SetupCard(CardInfo cardInfo, Gun gun, ApplyCardStats cardStats, CharacterStatModifiers statModifiers);
+        public virtual void SetupCard(CardInfo cardInfo, Gun gun, ApplyCardStats cardStats, CharacterStatModifiers statModifiers, Block block)
+        {
+            SetupCard(cardInfo, gun, cardStats, statModifiers);
+        }
         public abstract void OnAddCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats);
         public abstract void OnRemoveCard();
         public virtual bool GetEnabled()

--- a/UnboundLib/UnboundLib.csproj
+++ b/UnboundLib/UnboundLib.csproj
@@ -35,7 +35,7 @@
   </PropertyGroup>
   
   <PropertyGroup>
-    <RoundsFolder>D:\Program Files (x86)\Steam\steamapps\common\ROUNDS</RoundsFolder>
+    <RoundsFolder>C:\Program Files (x86)\Steam\steamapps\common\ROUNDS</RoundsFolder>
     <IndirectBuildTask>true</IndirectBuildTask>
     <DisableFastUpToDateCheck>true</DisableFastUpToDateCheck>
     <LangVersion>7.1</LangVersion>

--- a/UnboundLib/UnboundLib.csproj
+++ b/UnboundLib/UnboundLib.csproj
@@ -35,7 +35,7 @@
   </PropertyGroup>
   
   <PropertyGroup>
-    <RoundsFolder>C:\Program Files (x86)\Steam\steamapps\common\ROUNDS</RoundsFolder>
+    <RoundsFolder>D:\Program Files (x86)\Steam\steamapps\common\ROUNDS</RoundsFolder>
     <IndirectBuildTask>true</IndirectBuildTask>
     <DisableFastUpToDateCheck>true</DisableFastUpToDateCheck>
     <LangVersion>7.1</LangVersion>


### PR DESCRIPTION
Adds a block component to `CustomCard` and an overload for `SetupCard` to allow people to simply use that version instead of needing to add the component themselves.