### PR TITLE
ENH: added overloads for registering Action and Action<IGameModeHandler> hooks directly

### DIFF
--- a/UnboundLib/GameModes/GameModeHooks.cs
+++ b/UnboundLib/GameModes/GameModeHooks.cs
@@ -26,6 +26,11 @@ namespace UnboundLib.GameModes
                 this.Action = hook;
                 this.Priority = priority;
             }
+            public Hook(Func<IEnumerator> hook, int priority)
+            {
+                this.Action = (gm) => hook();
+                this.Priority = priority;
+            }
             public Hook(Action<IGameModeHandler> hook, int priority)
             {
                 this.Action = (gm) => ActionHook(hook, gm);

--- a/UnboundLib/GameModes/GameModeHooks.cs
+++ b/UnboundLib/GameModes/GameModeHooks.cs
@@ -26,6 +26,27 @@ namespace UnboundLib.GameModes
                 this.Action = hook;
                 this.Priority = priority;
             }
+            public Hook(Action<IGameModeHandler> hook, int priority)
+            {
+                this.Action = (gm) => ActionHook(hook, gm);
+                this.Priority = priority;
+            }
+            public Hook(Action hook, int priority)
+            {
+                this.Action = (gm) => ActionHook(hook, gm);
+                this.Priority = priority;
+            }
+            
+            private IEnumerator ActionHook(Action<IGameModeHandler> hook, IGameModeHandler gm)
+            {
+                hook(gm);
+                yield break;
+            }
+            private IEnumerator ActionHook(Action hook, IGameModeHandler gm)
+            {
+                hook();
+                yield break;
+            }
         }
 
         /// <summary>

--- a/UnboundLib/GameModes/GameModeManager.cs
+++ b/UnboundLib/GameModes/GameModeManager.cs
@@ -244,6 +244,10 @@ namespace UnboundLib.GameModes
         /// </summary>
         public static void AddOnceHook(string key, Func<IGameModeHandler, IEnumerator> action)
         {
+            if (action is null)
+            {
+                return;
+            }
             AddOnceHook(key, action, GameModeHooks.Priority.Normal);
         }
         /// <summary>
@@ -251,7 +255,62 @@ namespace UnboundLib.GameModes
         /// </summary>
         public static void AddOnceHook(string key, Func<IGameModeHandler, IEnumerator> action, int priority)
         {
-            if (action == null)
+            if (action is null)
+            {
+                return;
+            }
+            AddOnceHook(key, new GameModeHooks.Hook(action, priority));
+        }
+        /// <summary>
+        ///     Adds a hook that is automatically removed after it's triggered once.
+        /// </summary>
+        public static void AddOnceHook(string key, Action action)
+        {
+            if (action is null)
+            {
+                return;
+            }
+            AddOnceHook(key, action, GameModeHooks.Priority.Normal);
+        }
+        /// <summary>
+        ///     Adds a hook that is automatically removed after it's triggered once.
+        /// </summary>
+        public static void AddOnceHook(string key, Action action, int priority)
+        {
+            if (action is null)
+            {
+                return;
+            }
+            AddOnceHook(key, new GameModeHooks.Hook(action, priority));
+        }
+        /// <summary>
+        ///     Adds a hook that is automatically removed after it's triggered once.
+        /// </summary>
+        public static void AddOnceHook(string key, Action<IGameModeHandler> action)
+        {
+            if (action is null)
+            {
+                return;
+            }
+            AddOnceHook(key, action, GameModeHooks.Priority.Normal);
+        }
+        /// <summary>
+        ///     Adds a hook that is automatically removed after it's triggered once.
+        /// </summary>
+        public static void AddOnceHook(string key, Action<IGameModeHandler> action, int priority)
+        {
+            if (action is null)
+            {
+                return;
+            }
+            AddOnceHook(key, new GameModeHooks.Hook(action, priority));
+        }
+        /// <summary>
+        ///     Adds a hook that is automatically removed after it's triggered once.
+        /// </summary>
+        public static void AddOnceHook(string key, GameModeHooks.Hook hook)
+        {
+            if (hook is null)
             {
                 return;
             }
@@ -261,23 +320,67 @@ namespace UnboundLib.GameModes
 
             if (!onceHooks.ContainsKey(key))
             {
-                onceHooks.Add(key, new List<GameModeHooks.Hook>{ new GameModeHooks.Hook(action, priority) });
+                onceHooks.Add(key, new List<GameModeHooks.Hook>{ hook });
             }
             else
             {
-                onceHooks[key].Add(new GameModeHooks.Hook(action, priority));
+                onceHooks[key].Add(hook);
             }
 
-            AddHook(key, action);
+            AddHook(key, hook);
         }
 
         public static void AddHook(string key, Func<IGameModeHandler, IEnumerator> action)
         {
+            if (action is null)
+            {
+                return;
+            }
             AddHook(key, action, GameModeHooks.Priority.Normal);
         }
         public static void AddHook(string key, Func<IGameModeHandler, IEnumerator> action, int priority)
         {
-            if (action == null)
+            if (action is null)
+            {
+                return;
+            }
+            AddHook(key, new GameModeHooks.Hook(action, priority));
+        }
+        public static void AddHook(string key, Action<IGameModeHandler> action)
+        {
+            if (action is null)
+            {
+                return;
+            }
+            AddHook(key, action, GameModeHooks.Priority.Normal);
+        }
+        public static void AddHook(string key, Action<IGameModeHandler> action, int priority)
+        {
+            if (action is null)
+            {
+                return;
+            }
+            AddHook(key, new GameModeHooks.Hook(action, priority));
+        }
+        public static void AddHook(string key, Action action)
+        {
+            if (action is null)
+            {
+                return;
+            }
+            AddHook(key, action, GameModeHooks.Priority.Normal);
+        }
+        public static void AddHook(string key, Action action, int priority)
+        {
+            if (action is null)
+            {
+                return;
+            }
+            AddHook(key, new GameModeHooks.Hook(action, priority));
+        }
+        public static void AddHook(string key, GameModeHooks.Hook hook)
+        {
+            if (hook is null)
             {
                 return;
             }
@@ -287,11 +390,11 @@ namespace UnboundLib.GameModes
 
             if (!hooks.ContainsKey(key))
             {
-                hooks.Add(key, new List<GameModeHooks.Hook> { new GameModeHooks.Hook(action, priority) });
+                hooks.Add(key, new List<GameModeHooks.Hook> { hook });
             }
             else
             {
-                hooks[key].Add(new GameModeHooks.Hook(action, priority));
+                hooks[key].Add(hook);
             }
         }
         public static void RemoveHook(string key, GameModeHooks.Hook hook)

--- a/UnboundLib/GameModes/GameModeManager.cs
+++ b/UnboundLib/GameModes/GameModeManager.cs
@@ -264,6 +264,28 @@ namespace UnboundLib.GameModes
         /// <summary>
         ///     Adds a hook that is automatically removed after it's triggered once.
         /// </summary>
+        public static void AddOnceHook(string key, Func<IEnumerator> action)
+        {
+            if (action is null)
+            {
+                return;
+            }
+            AddOnceHook(key, action, GameModeHooks.Priority.Normal);
+        }
+        /// <summary>
+        ///     Adds a hook that is automatically removed after it's triggered once.
+        /// </summary>
+        public static void AddOnceHook(string key, Func<IEnumerator> action, int priority)
+        {
+            if (action is null)
+            {
+                return;
+            }
+            AddOnceHook(key, new GameModeHooks.Hook(action, priority));
+        }
+        /// <summary>
+        ///     Adds a hook that is automatically removed after it's triggered once.
+        /// </summary>
         public static void AddOnceHook(string key, Action action)
         {
             if (action is null)
@@ -339,6 +361,22 @@ namespace UnboundLib.GameModes
             AddHook(key, action, GameModeHooks.Priority.Normal);
         }
         public static void AddHook(string key, Func<IGameModeHandler, IEnumerator> action, int priority)
+        {
+            if (action is null)
+            {
+                return;
+            }
+            AddHook(key, new GameModeHooks.Hook(action, priority));
+        }
+        public static void AddHook(string key, Func<IEnumerator> action)
+        {
+            if (action is null)
+            {
+                return;
+            }
+            AddHook(key, action, GameModeHooks.Priority.Normal);
+        }
+        public static void AddHook(string key, Func<IEnumerator> action, int priority)
         {
             if (action is null)
             {


### PR DESCRIPTION
Many times, devs just need an `Action` or an `Action<IGameModeHandler>` hook, instead of a `Func<IGameModeHandler, IEnumerator>` and are forced to do something messy for every one of their hooks, like:

```
void MyActualHook()
{
    // do stuff
}
IEnumerator Hook(IGameModeHandler gm)
{
    MyActualHook();
    yield break;
}

GameModeManager.AddHook("OnBattleStart", Hook);
```

This PR implements all of this for users in the `GameModeHooks.Hook` constructor overloads, and exposes overloads to `GameModeManager.AddHook` and `GameModeManager.AddOnceHook` so that the above example becomes just

```
GameModeManager.AddHook("OnBattleStart", MyActualHook);
```