### PR TITLE
Create CardChoicePatchGetSourceCard.cs

### DIFF
--- a/UnboundLib/Patches/CardChoicePatchGetSourceCard.cs
+++ b/UnboundLib/Patches/CardChoicePatchGetSourceCard.cs
@@ -1,0 +1,25 @@
+﻿using HarmonyLib;
+
+namespace UnboundLib.Patches
+{
+    [HarmonyPatch(typeof(CardChoice))]
+    public class CardChoicePatchGetSourceCard
+    {
+        [HarmonyPrefix]
+        [HarmonyPatch(nameof(CardChoice.GetSourceCard))]
+        private static bool CheckHiddenCards(CardChoice __instance, CardInfo info, ref CardInfo __result)
+        {
+            for (int i = 0; i < __instance.cards.Length; i++)
+            {
+                if ((__instance.cards[i].gameObject.name + "(Clone)") == info.gameObject.name)
+                {
+                    __result = __instance.cards[i];
+                    break;
+                }
+            }
+            __result = null;
+
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
Fixes an issue where the game will fetch the wrong source card for other players when cards share the same name.