### PR TITLE
Custom Card patch

### DIFF
--- a/UnboundLib/Cards/CustomCard.cs
+++ b/UnboundLib/Cards/CustomCard.cs
@@ -191,7 +191,7 @@ namespace UnboundLib.Cards
                 CardManager.cards.Add(cardInfo.gameObject.name, new Card(customCard.GetModName().Sanitize(), Unbound.config.Bind("Cards: " + customCard.GetModName().Sanitize(), cardInfo.gameObject.name, true), cardInfo));
             }
 
-            cardInfo.ExecuteAfterFrames(5, () =>
+            Unbound.Instance.ExecuteAfterFrames(5, () =>
             {
                 callback?.Invoke(cardInfo);
             });
@@ -220,7 +220,7 @@ namespace UnboundLib.Cards
                 CardManager.cards.Add(cardInfo.gameObject.name, new Card(customCard.GetModName().Sanitize(), Unbound.config.Bind("Cards: " + customCard.GetModName().Sanitize(), cardInfo.gameObject.name, true), cardInfo));
             }
 
-            cardInfo.ExecuteAfterFrames(5, () =>
+            Unbound.Instance.ExecuteAfterFrames(5, () =>
             {
                 callback?.Invoke(cardInfo);
             });
@@ -240,7 +240,7 @@ namespace UnboundLib.Cards
                 CardManager.cards.Add(cardInfo.gameObject.name, new Card(customCard.GetModName().Sanitize(), Unbound.config.Bind("Cards: " + customCard.GetModName().Sanitize(), cardInfo.gameObject.name, true), cardInfo));
             }
 
-            cardInfo.ExecuteAfterFrames(5, () =>
+            Unbound.Instance.ExecuteAfterFrames(5, () =>
             {
                 callback?.Invoke(cardInfo);
             });
@@ -259,7 +259,7 @@ namespace UnboundLib.Cards
                 CardManager.cards.Add(cardInfo.gameObject.name, new Card(cardname.Sanitize(), Unbound.config.Bind("Cards: " + cardname.Sanitize(), cardInfo.gameObject.name, true), cardInfo));
             }
 
-            cardInfo.ExecuteAfterFrames(5, () =>
+            Unbound.Instance.ExecuteAfterFrames(5, () =>
             {
                 callback?.Invoke(cardInfo);
             });
@@ -278,7 +278,7 @@ namespace UnboundLib.Cards
                 CardManager.cards.Add(cardInfo.gameObject.name, new Card(this.GetModName().Sanitize(), Unbound.config.Bind("Cards: " + this.GetModName().Sanitize(), cardInfo.gameObject.name, true), cardInfo));
             }
 
-            cardInfo.ExecuteAfterFrames(5, () =>
+            Unbound.Instance.ExecuteAfterFrames(5, () =>
             {
                 callback?.Invoke(cardInfo);
             });

--- a/UnboundLib/Cards/CustomCard.cs
+++ b/UnboundLib/Cards/CustomCard.cs
@@ -236,6 +236,25 @@ namespace UnboundLib.Cards
             });
         }
 
+        public void RegisterUnityCard(Action<CardInfo> callback)
+        {
+            CardInfo cardInfo = this.gameObject.GetComponent<CardInfo>();
+
+            cardInfo.gameObject.name = $"__{this.GetModName()}__{this.GetTitle()}".Sanitize();
+
+            PhotonNetwork.PrefabPool.RegisterPrefab(cardInfo.gameObject.name, this.gameObject);
+
+            if (this.GetEnabled())
+            {
+                CardManager.cards.Add(cardInfo.gameObject.name, new Card(this.GetModName().Sanitize(), Unbound.config.Bind("Cards: " + this.GetModName().Sanitize(), cardInfo.gameObject.name, true), cardInfo));
+            }
+
+            cardInfo.ExecuteAfterFrames(5, () =>
+            {
+                callback?.Invoke(cardInfo);
+            });
+        }
+
         private static void DestroyChildren(GameObject t)
         {
             while (t.transform.childCount > 0)

--- a/UnboundLib/Cards/CustomCard.cs
+++ b/UnboundLib/Cards/CustomCard.cs
@@ -197,6 +197,35 @@ namespace UnboundLib.Cards
             });
         }
 
+        public void BuildUnityCard(Action<CardInfo> callback)
+        {
+            CardInfo cardInfo = this.gameObject.GetComponent<CardInfo>();
+            CustomCard customCard = this;
+            GameObject cardPrefab = this.gameObject;
+
+            cardInfo.cardBase = customCard.GetCardBase();
+            cardInfo.cardStats = customCard.GetStats();
+            cardInfo.cardName = customCard.GetTitle();
+            cardInfo.gameObject.name = $"__{customCard.GetModName()}__{customCard.GetTitle()}".Sanitize();
+            cardInfo.cardDestription = customCard.GetDescription();
+            cardInfo.sourceCard = cardInfo;
+            cardInfo.rarity = customCard.GetRarity();
+            cardInfo.colorTheme = customCard.GetTheme();
+            cardInfo.cardArt = customCard.GetCardArt();
+
+            PhotonNetwork.PrefabPool.RegisterPrefab(cardInfo.gameObject.name, cardPrefab);
+
+            if (customCard.GetEnabled())
+            {
+                CardManager.cards.Add(cardInfo.gameObject.name, new Card(customCard.GetModName().Sanitize(), Unbound.config.Bind("Cards: " + customCard.GetModName().Sanitize(), cardInfo.gameObject.name, true), cardInfo));
+            }
+
+            cardInfo.ExecuteAfterFrames(5, () =>
+            {
+                callback?.Invoke(cardInfo);
+            });
+        }
+
         public static void RegisterUnityCard<T>(GameObject cardPrefab, Action<CardInfo> callback) where T : CustomCard
         {
             CardInfo cardInfo = cardPrefab.GetComponent<CardInfo>();

--- a/UnboundLib/Cards/CustomCard.cs
+++ b/UnboundLib/Cards/CustomCard.cs
@@ -217,6 +217,25 @@ namespace UnboundLib.Cards
             });
         }
 
+        public static void RegisterUnityCard(GameObject cardPrefab, string modInitials, string cardname, bool enabled, Action<CardInfo> callback)
+        {
+            CardInfo cardInfo = cardPrefab.GetComponent<CardInfo>();
+
+            cardInfo.gameObject.name = $"__{modInitials}__{cardname}".Sanitize();
+
+            PhotonNetwork.PrefabPool.RegisterPrefab(cardInfo.gameObject.name, cardPrefab);
+
+            if (enabled)
+            {
+                CardManager.cards.Add(cardInfo.gameObject.name, new Card(cardname.Sanitize(), Unbound.config.Bind("Cards: " + cardname.Sanitize(), cardInfo.gameObject.name, true), cardInfo));
+            }
+
+            cardInfo.ExecuteAfterFrames(5, () =>
+            {
+                callback?.Invoke(cardInfo);
+            });
+        }
+
         private static void DestroyChildren(GameObject t)
         {
             while (t.transform.childCount > 0)

--- a/UnboundLib/Cards/CustomCard.cs
+++ b/UnboundLib/Cards/CustomCard.cs
@@ -191,6 +191,8 @@ namespace UnboundLib.Cards
                 CardManager.cards.Add(cardInfo.gameObject.name, new Card(customCard.GetModName().Sanitize(), Unbound.config.Bind("Cards: " + customCard.GetModName().Sanitize(), cardInfo.gameObject.name, true), cardInfo));
             }
 
+            customCard.Awake();
+
             Unbound.Instance.ExecuteAfterFrames(5, () =>
             {
                 callback?.Invoke(cardInfo);
@@ -219,6 +221,8 @@ namespace UnboundLib.Cards
             {
                 CardManager.cards.Add(cardInfo.gameObject.name, new Card(customCard.GetModName().Sanitize(), Unbound.config.Bind("Cards: " + customCard.GetModName().Sanitize(), cardInfo.gameObject.name, true), cardInfo));
             }
+
+            this.Awake();
 
             Unbound.Instance.ExecuteAfterFrames(5, () =>
             {

--- a/UnboundLib/Cards/CustomCard.cs
+++ b/UnboundLib/Cards/CustomCard.cs
@@ -169,6 +169,54 @@ namespace UnboundLib.Cards
             });
         }
 
+        public static void BuildUnityCard<T>(GameObject cardPrefab, Action<CardInfo> callback) where T : CustomCard
+        {
+            CardInfo cardInfo = cardPrefab.GetComponent<CardInfo>();
+            CustomCard customCard = cardPrefab.GetOrAddComponent<T>();
+
+            cardInfo.cardBase = customCard.GetCardBase();
+            cardInfo.cardStats = customCard.GetStats();
+            cardInfo.cardName = customCard.GetTitle();
+            cardInfo.gameObject.name = $"__{customCard.GetModName()}__{customCard.GetTitle()}".Sanitize();
+            cardInfo.cardDestription = customCard.GetDescription();
+            cardInfo.sourceCard = cardInfo;
+            cardInfo.rarity = customCard.GetRarity();
+            cardInfo.colorTheme = customCard.GetTheme();
+            cardInfo.cardArt = customCard.GetCardArt();
+
+            PhotonNetwork.PrefabPool.RegisterPrefab(cardInfo.gameObject.name, cardPrefab);
+
+            if (customCard.GetEnabled())
+            {
+                CardManager.cards.Add(cardInfo.gameObject.name, new Card(customCard.GetModName().Sanitize(), Unbound.config.Bind("Cards: " + customCard.GetModName().Sanitize(), cardInfo.gameObject.name, true), cardInfo));
+            }
+
+            cardInfo.ExecuteAfterFrames(5, () =>
+            {
+                callback?.Invoke(cardInfo);
+            });
+        }
+
+        public static void RegisterUnityCard<T>(GameObject cardPrefab, Action<CardInfo> callback) where T : CustomCard
+        {
+            CardInfo cardInfo = cardPrefab.GetComponent<CardInfo>();
+            CustomCard customCard = cardPrefab.GetOrAddComponent<T>();
+
+            cardInfo.gameObject.name = $"__{customCard.GetModName()}__{customCard.GetTitle()}".Sanitize();
+
+            PhotonNetwork.PrefabPool.RegisterPrefab(cardInfo.gameObject.name, cardPrefab);
+
+            if (customCard.GetEnabled())
+            {
+                CardManager.cards.Add(cardInfo.gameObject.name, new Card(customCard.GetModName().Sanitize(), Unbound.config.Bind("Cards: " + customCard.GetModName().Sanitize(), cardInfo.gameObject.name, true), cardInfo));
+            }
+
+            cardInfo.ExecuteAfterFrames(5, () =>
+            {
+                callback?.Invoke(cardInfo);
+            });
+        }
+
         private static void DestroyChildren(GameObject t)
         {
             while (t.transform.childCount > 0)

--- a/UnboundLib/Patches/CardChoicePatchGetSourceCard.cs
+++ b/UnboundLib/Patches/CardChoicePatchGetSourceCard.cs
@@ -1,0 +1,25 @@
+﻿using HarmonyLib;
+
+namespace UnboundLib.Patches
+{
+    [HarmonyPatch(typeof(CardChoice))]
+    public class CardChoicePatchGetSourceCard
+    {
+        [HarmonyPrefix]
+        [HarmonyPatch(nameof(CardChoice.GetSourceCard))]
+        private static bool CheckHiddenCards(CardChoice __instance, CardInfo info, ref CardInfo __result)
+        {
+            for (int i = 0; i < __instance.cards.Length; i++)
+            {
+                if ((__instance.cards[i].gameObject.name + "(Clone)") == info.gameObject.name)
+                {
+                    __result = __instance.cards[i];
+                    break;
+                }
+            }
+            __result = null;
+
+            return false;
+        }
+    }
+}

--- a/UnboundLib/Unbound.cs
+++ b/UnboundLib/Unbound.cs
@@ -25,7 +25,7 @@ namespace UnboundLib
     {
         private const string ModId = "com.willis.rounds.unbound";
         private const string ModName = "Rounds Unbound";
-        public const string Version = "3.2.0";
+        public const string Version = "3.2.1";
 
         public static Unbound Instance { get; private set; }
         public static readonly ConfigFile config = new ConfigFile(Path.Combine(Paths.ConfigPath, "UnboundLib.cfg"), true);


### PR DESCRIPTION
Adds the ability to register cards made in unity.

```
static void BuildUnityCard<T>(GameObject cardPrefab, Action<CardInfo> callback)
```
This function runs much the same as `Buildcard()`, except it doesn't instantiate a card object (thus leaving the prefab in resources) and utilizes pushed prefab to do so.

```
void BuildUnityCard(Action<CardInfo> callback)
```
This will build the card using the customcard component on a prefab, and then register that prefab accordingly.

```
static void RegisterUnityCard<T>(GameObject cardPrefab, Action<CardInfo> callback)
```
This will Get/Add the passed customcard component, adjust the gameobject name as appropriate, and then registers the card to the card manager and photon pools.

```
static void RegisterUnityCard(GameObject cardPrefab, string modInitials, string cardname, bool enabled, Action<CardInfo> callback)
```
This does not add a customcard component, but adjusts the prefab name and registers it to the card manager and photon pools.

```
void RegisterUnityCard(Action<CardInfo> callback)
```
This will register a card, using the customcard component on a prefab.