### PR TITLE
Card Manager Update

### DIFF
--- a/UnboundLib/Utils/CardManager.cs
+++ b/UnboundLib/Utils/CardManager.cs
@@ -142,10 +142,6 @@ namespace UnboundLib.Utils
             }
 
             string cardName = cardInfo.gameObject.name;
-            if (cardInfo.gameObject.GetComponent<CustomCard>() == null)
-            {
-                cardName = cardInfo.cardName;
-            }
             if (!cards.ContainsKey(cardName)) return;
             
             cards[cardName].enabled = true;
@@ -177,10 +173,6 @@ namespace UnboundLib.Utils
             }
 
             string cardName = cardInfo.gameObject.name;
-            if (cardInfo.gameObject.GetComponent<CustomCard>() == null)
-            {
-                cardName = cardInfo.cardName;
-            }
             if (!cards.ContainsKey(cardName)) return;
 
             cards[cardName].enabled = false;

--- a/UnboundLib/Utils/UI/ToggleCardsMenuHandler.cs
+++ b/UnboundLib/Utils/UI/ToggleCardsMenuHandler.cs
@@ -219,7 +219,7 @@ namespace UnboundLib.Utils.UI
                 // Create category buttons
                 // sort categories
                 // always have Vanilla first, then sort most cards -> least cards, followed by "Modded" at the end (if it exists)
-                List<string> sortedCategories = new[] { "Vanilla" }.Concat(CardManager.categories.OrderByDescending(x => CardManager.GetCardsInCategory(x).Length).ThenBy(x => x).Except(new[] { "Vanilla" })).ToList();
+                List<string> sortedCategories = new[] { "Vanilla" }.Concat(CardManager.categories.OrderBy(x => x).Except(new[] { "Vanilla" })).ToList();
                 
                 foreach (var category in sortedCategories)
                 {

--- a/UnboundLib/Utils/UI/ToggleLevelMenuHandler.cs
+++ b/UnboundLib/Utils/UI/ToggleLevelMenuHandler.cs
@@ -259,7 +259,8 @@ namespace UnboundLib.Utils.UI
                 var viewingText = mapMenuCanvas.transform.Find("MapMenu/Top/Viewing").gameObject.GetComponentInChildren<TextMeshProUGUI>();
 
                 // Create category buttons
-                foreach (var category in LevelManager.categories)
+                List<string> sortedCategories = new[] { "Vanilla", "Default physics" }.Concat(LevelManager.categories.OrderBy(c => c).Except(new[] { "Vanilla", "Default physics" })).ToList();
+                foreach (var category in sortedCategories)
                 {
                     var categoryObj = Instantiate(categoryButton, categoryContent);
                     categoryObj.SetActive(true);


### PR DESCRIPTION
Updated how cards were stored to avoid name coalitions with modded cards not using the custom card mono.

Patched CardChoice to preserve modded cards when quitting to main menu, and removed to duplicate prefab name error that it would throw. 