### PR TITLE
MenuHandler CreateMenu Fix and Update

### DIFF
--- a/UnboundLib/Unbound.cs
+++ b/UnboundLib/Unbound.cs
@@ -25,7 +25,7 @@ namespace UnboundLib
     {
         private const string ModId = "com.willis.rounds.unbound";
         private const string ModName = "Rounds Unbound";
-        public const string Version = "3.2.6";
+        public const string Version = "3.2.7";
 
         public static Unbound Instance { get; private set; }
         public static readonly ConfigFile config = new ConfigFile(Path.Combine(Paths.ConfigPath, "UnboundLib.cfg"), true);

--- a/UnboundLib/Utils/UI/MenuHandler.cs
+++ b/UnboundLib/Utils/UI/MenuHandler.cs
@@ -49,6 +49,12 @@ namespace UnboundLib.Utils.UI
         // Creates a menu and returns its gameObject
         public static GameObject CreateMenu(string Name, UnityAction buttonAction, GameObject parentForButton, int size = 50, bool forceUpper = true, bool setBarHeight = true, GameObject parentForMenu = null,  bool setFontSize = true, int siblingIndex = -1)
         {
+            return CreateMenu(Name, buttonAction, parentForButton, out GameObject menuButton, size, forceUpper, setBarHeight, parentForMenu, setFontSize, siblingIndex);
+        }
+
+        // Creates a menu and returns its gameObject along with outputting the menubutton it created.
+        public static GameObject CreateMenu(string Name, UnityAction buttonAction, GameObject parentForButton, out GameObject menuButton, int size = 50, bool forceUpper = true, bool setBarHeight = true, GameObject parentForMenu = null, bool setFontSize = true, int siblingIndex = -1)
+        {
             var obj = parentForMenu is null ? Object.Instantiate(menuBase, MainMenuHandler.instance.transform.Find("Canvas/ListSelector")) : Object.Instantiate(menuBase, parentForMenu.transform);
             obj.name = Name;
             
@@ -62,7 +68,8 @@ namespace UnboundLib.Utils.UI
             Transform buttonParent = null;
             if (parentForButton.transform.Find("Group/Grid/Scroll View/Viewport/Content")) buttonParent = parentForButton.transform.Find("Group/Grid/Scroll View/Viewport/Content");
             else if (parentForButton.transform.Find("Group")) buttonParent = parentForButton.transform.Find("Group");
-            
+            else buttonParent = parentForButton.transform;
+
             // Create button to menu
             var button = Object.Instantiate(buttonBase, buttonParent);
             button.GetComponent<ListMenuButton>().setBarHeight = setBarHeight ? size : 0;
@@ -92,6 +99,8 @@ namespace UnboundLib.Utils.UI
                 };
             }
             button.GetComponent<Button>().onClick.AddListener(buttonAction);
+
+            menuButton = button;
 
             return obj;
         }

--- a/UnboundLib/Utils/UI/ModOptions.cs
+++ b/UnboundLib/Utils/UI/ModOptions.cs
@@ -131,7 +131,12 @@ namespace UnboundLib.Utils.UI
                 mmenu.transform.Find("Group/Back").gameObject.GetComponent<Button>().onClick
                     .AddListener(disableOldMenu);
 
-                menu.guiAction.Invoke(mmenu);
+                try { menu.guiAction.Invoke(mmenu); }
+                catch (Exception e) 
+                {
+                    UnityEngine.Debug.LogError($"Exception thrown when attempting to build menu '{menu.menuName}', see log below for details.");
+                    UnityEngine.Debug.LogException(e);
+                }
             }
 
             // Create menu's for mods that do not use the new UI


### PR DESCRIPTION
* Fixes an issue where inputting a parent for the menuButton doesn't actually utilize that parent object, even if it doesn't contain the structure that unbound wants to automagically hook up to.
* Adds a way to easily fetch the created menu button for additional changes.