### PR TITLE
Improve gamemode hook error logs

### DIFF
--- a/UnboundLib/GameModes/GameModeHooks.cs
+++ b/UnboundLib/GameModes/GameModeHooks.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections;
+using System.Diagnostics;
+using System.Reflection;
 namespace UnboundLib.GameModes
 {
     // When possible, use these keys when adding game hooks to a game mode
@@ -17,6 +19,7 @@ namespace UnboundLib.GameModes
             public const int VeryHigh = 700;
             public const int First = 800;
         }
+
         public class Hook
         {
             public Func<IGameModeHandler, IEnumerator> Action;
@@ -25,6 +28,20 @@ namespace UnboundLib.GameModes
             {
                 this.Action = hook;
                 this.Priority = priority;
+            }
+        }
+
+        internal class HookRegistration
+        {
+            public Hook Hook { get; private set; }
+            public string Identifier { get; private set; }
+            public string CallStack { get; private set; }
+
+            public HookRegistration(Hook hook, Assembly callingAssembly, StackTrace trace)
+            {
+                this.Hook = hook;
+                this.Identifier = callingAssembly.GetName().Name;
+                this.CallStack = trace.ToString();
             }
         }
 

--- a/UnboundLib/Patches/GM_Test.cs
+++ b/UnboundLib/Patches/GM_Test.cs
@@ -1,5 +1,4 @@
 ﻿using HarmonyLib;
-using UnboundLib.GameModes;
 using System.Linq;
 using System.Collections.Generic;
 
@@ -9,19 +8,6 @@ namespace UnboundLib.Patches
     [HarmonyPatch(typeof(GM_Test), "Start")]
     class GM_Test_Patch_Start
     {
-        static void Prefix()
-        {
-            GameModeManager.TriggerHook(GameModeHooks.HookInitStart);
-            GameModeManager.TriggerHook(GameModeHooks.HookInitEnd);
-            GameModeManager.TriggerHook(GameModeHooks.HookGameStart);
-        }
-
-        static void Postfix()
-        {
-            GameModeManager.TriggerHook(GameModeHooks.HookRoundStart);
-            GameModeManager.TriggerHook(GameModeHooks.HookBattleStart);
-        }
-
         static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
         {
             // Remove the default player joined and died -hooks. We'll add them back through the GameMode abstraction layer.

--- a/UnboundLib/Unbound.cs
+++ b/UnboundLib/Unbound.cs
@@ -25,7 +25,7 @@ namespace UnboundLib
     {
         private const string ModId = "com.willis.rounds.unbound";
         private const string ModName = "Rounds Unbound";
-        public const string Version = "3.2.10";
+        public const string Version = "3.2.11";
 
         public static Unbound Instance { get; private set; }
         public static readonly ConfigFile config = new ConfigFile(Path.Combine(Paths.ConfigPath, "UnboundLib.cfg"), true);

--- a/UnboundLib/Unbound.cs
+++ b/UnboundLib/Unbound.cs
@@ -158,6 +158,21 @@ namespace UnboundLib
                 self.StartCoroutine(ArmsRaceStartCoroutine(orig, self));
             };
 
+            IEnumerator SandboxStartCoroutine(On.GM_Test.orig_Start orig, GM_Test self)
+            {
+                yield return GameModeManager.TriggerHook(GameModeHooks.HookInitStart);
+                yield return GameModeManager.TriggerHook(GameModeHooks.HookInitEnd);
+                yield return GameModeManager.TriggerHook(GameModeHooks.HookGameStart);
+                orig(self);
+                yield return GameModeManager.TriggerHook(GameModeHooks.HookRoundStart);
+                yield return GameModeManager.TriggerHook(GameModeHooks.HookBattleStart);
+            }
+
+            On.GM_Test.Start += (orig, self) =>
+            {
+                self.StartCoroutine(SandboxStartCoroutine(orig, self));
+            };
+
             GameModeManager.AddHook(GameModeHooks.HookGameStart, handler => SyncModClients.DisableSyncModUi(SyncModClients.uiParent));
 
             // hook for closing ongoing lobbies


### PR DESCRIPTION
- Improve hook error logs to include information about who added the hook and where.
- Fix hooks not triggering in sandbox due to missing `yield return` statements.