### PR TITLE
Optimize the config saving, by using "Bulk Saving" method instead.

### DIFF
--- a/UnboundLib/Unbound.cs
+++ b/UnboundLib/Unbound.cs
@@ -85,6 +85,7 @@ namespace UnboundLib
         {
             // Add UNBOUND text to the main menu screen
             bool firstTime = true;
+            config.SaveOnConfigSet = false;
 
             On.MainMenuHandler.Awake += (orig, self) =>
             {
@@ -336,6 +337,12 @@ namespace UnboundLib
 
             // sync modded clients
             networkEvents.OnJoinedRoomEvent += SyncModClients.RequestSync;
+
+            this.ExecuteAfterSeconds(1, () =>
+            {
+                config.Save();
+                config.SaveOnConfigSet = true;
+            });
         }
 
         private void Update()

--- a/UnboundLib/Utils/CardManager.cs
+++ b/UnboundLib/Utils/CardManager.cs
@@ -122,10 +122,12 @@ namespace UnboundLib.Utils
 
         public static void EnableCards(CardInfo[] cardInfos, bool saved = true)
         {
+            Unbound.config.SaveOnConfigSet = false;
             foreach (var card in cardInfos)
             {
                 EnableCard(card, saved);
             }
+            Unbound.config.SaveOnConfigSet = true;
         }
 
         public static void EnableCard(CardInfo cardInfo, bool saved = true)
@@ -154,10 +156,12 @@ namespace UnboundLib.Utils
 
         public static void DisableCards(CardInfo[] cardInfos, bool saved = true)
         {
+            Unbound.config.SaveOnConfigSet = false;
             foreach (var card in cardInfos)
             {
                 DisableCard(card, saved);
             }
+            Unbound.config.SaveOnConfigSet = true;
         }
 
         public static void DisableCard(CardInfo cardInfo, bool saved = true)
@@ -186,19 +190,25 @@ namespace UnboundLib.Utils
         public static void EnableCategory(string categoryName)
         {
             if (categoryBools.ContainsKey(categoryName)) categoryBools[categoryName].Value = true;
+
+            Unbound.config.SaveOnConfigSet = false;
             foreach (string cardname in GetCardsInCategory(categoryName))
             {
                 EnableCard(cards[cardname].cardInfo, true);
             }
+            Unbound.config.SaveOnConfigSet = true;
         }
 
         public static void DisableCategory(string categoryName)
         {
             if (categoryBools.ContainsKey(categoryName)) categoryBools[categoryName].Value = false;
+
+            Unbound.config.SaveOnConfigSet = false;
             foreach (string cardname in GetCardsInCategory(categoryName))
             {
                 DisableCard(cards[cardname].cardInfo, true);
             }
+            Unbound.config.SaveOnConfigSet = true;
         }
 
         public static bool IsCardActive(CardInfo card)

--- a/UnboundLib/Utils/UI/ToggleCardsMenuHandler.cs
+++ b/UnboundLib/Utils/UI/ToggleCardsMenuHandler.cs
@@ -121,6 +121,7 @@ namespace UnboundLib.Utils.UI
                 toggledAll = !toggledAll;
 
                 var cardsInCategory = CardManager.GetCardsInCategory(currentCategory);
+                Unbound.config.SaveOnConfigSet = false;
                 if (toggledAll)
                 {
                     var objectsInCategory = GetCardObjects(cardsInCategory);
@@ -139,6 +140,7 @@ namespace UnboundLib.Utils.UI
                         cardObjs[cardObject].Invoke();
                     }
                 }
+                Unbound.config.SaveOnConfigSet = true;
             });
 
             // get and set info button
@@ -336,15 +338,18 @@ namespace UnboundLib.Utils.UI
         private void DisableCardsInCategory(string category)
         {
             if (!cardObjectsInCategory.ContainsKey(category)) return;
+            Unbound.config.SaveOnConfigSet = false;
             foreach (GameObject cardObject in cardObjectsInCategory[category])
             {
                 cardObject.SetActive(false);
             }
+            Unbound.config.SaveOnConfigSet = true;
         }
 
         private IEnumerator EnableCardsInCategory(string category)
         {
             if (!cardObjectsInCategory.ContainsKey(category)) yield break;
+            Unbound.config.SaveOnConfigSet = false;
             foreach (GameObject cardObject in cardObjectsInCategory[category])
             {
                 var active = ActiveOnSearch(cardObject.name);
@@ -352,6 +357,7 @@ namespace UnboundLib.Utils.UI
                 UpdateVisualsCardObj(cardObject);
                 yield return new WaitForEndOfFrame();
             }
+            Unbound.config.SaveOnConfigSet = true;
         }
 
         internal static Color uncommonColor = new Color(0, 0.5f, 1, 1);


### PR DESCRIPTION
# Summary
This change disables the config `SaveOnConfigSet` during `Unbound` initialization, and performs a single save after `Unbound` is fully loaded.

# Implementation
- Set `config.SaveOnConfigSet = false` at startup to prevent per-bind saves.
- After `Unbound` is fully loaded, schedule a one second save
  ```cs
  this.ExecuteAfterSeconds(1, () =>
  {
      config.Save();
      config.SaveOnConfigSet = true;
  });
  ```
# Performance Impact
Tested with a **117 mods** modpack (019c86b6-941f-216a-a5c1-8ed4ceb102c4).
- Baseline: **99,388 ms** average startup time
- With change: **46,563 ms** average startup time
- ~50% reduction in startup time (≈2.1× faster)